### PR TITLE
Added sourceGooruId as param for resource event logging

### DIFF
--- a/api/src/main/java/org/ednovo/gooru/domain/service/collection/CollectionBoServiceImpl.java
+++ b/api/src/main/java/org/ednovo/gooru/domain/service/collection/CollectionBoServiceImpl.java
@@ -330,7 +330,7 @@ public class CollectionBoServiceImpl extends AbstractResourceServiceImpl impleme
 		CollectionItem collectionItem = new CollectionItem();
 		collectionItem.setItemType(ADDED);
 		collectionItem = createCollectionItem(collectionItem, collection, copyQuestion, user);
-		getCollectionEventLog().collectionItemEventLog(collectionId, collectionItem, user.getPartyUid(), QUESTION, null, ADD);
+		getCollectionEventLog().collectionItemEventLog(collectionId, collectionItem, question.getGooruOid(), user.getPartyUid(), QUESTION, null, ADD);
 		updateCollectionMetaDataSummary(collection.getContentId(), QUESTION, ADD);
 		Map<String, Object> metaData = generateQuestionMetaData(copyQuestion, copyQuestion, user);
 		createContentMeta(copyQuestion, metaData);

--- a/api/src/main/java/org/ednovo/gooru/domain/service/eventlogs/CollectionEventLog.java
+++ b/api/src/main/java/org/ednovo/gooru/domain/service/eventlogs/CollectionEventLog.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import net.sf.json.JSONArray;
 
+import org.apache.commons.lang.StringUtils;
 import org.ednovo.gooru.core.api.model.Collection;
 import org.ednovo.gooru.core.api.model.CollectionItem;
 import org.ednovo.gooru.core.api.model.CollectionType;
@@ -21,7 +22,7 @@ public class CollectionEventLog extends EventLog {
 
 	@Autowired
 	private ClassRepository classRepository;
-	
+
 	@Autowired
 	private CollectionDao collectionDao;
 
@@ -41,27 +42,27 @@ public class CollectionEventLog extends EventLog {
 				JSONArray classIds = new JSONArray();
 				classIds.addAll(classUids);
 				payLoadObject.put(CLASS_GOORU_IDS, classIds);
-				SessionContextSupport.putLogParameter(EVENT_NAME, action.equalsIgnoreCase(CREATE)? ITEM_CREATE:CLASS_ITEM_DELETE);
+				SessionContextSupport.putLogParameter(EVENT_NAME, action.equalsIgnoreCase(CREATE) ? ITEM_CREATE : CLASS_ITEM_DELETE);
 			} else {
-				SessionContextSupport.putLogParameter(EVENT_NAME, action.equalsIgnoreCase(CREATE)? ITEM_CREATE:ITEM_DELETE);
+				SessionContextSupport.putLogParameter(EVENT_NAME, action.equalsIgnoreCase(CREATE) ? ITEM_CREATE : ITEM_DELETE);
 			}
 			payLoadObject.put(MODE, action);
-			payLoadObject.put(ITEM_SEQUENCE,collection.getItemSequence());
-			if(action.equalsIgnoreCase(CREATE)){
+			payLoadObject.put(ITEM_SEQUENCE, collection.getItemSequence());
+			if (action.equalsIgnoreCase(CREATE)) {
 				payLoadObject.put(DATA, data);
-				payLoadObject.put(ITEM_ID,collection.getCollectionItemId());
+				payLoadObject.put(ITEM_ID, collection.getCollectionItemId());
 			}
 			if (collectionType.equalsIgnoreCase(CollectionType.ASSESSMENT.getCollectionType())) {
 				payLoadObject.put(TYPE, ASSESSMENT);
-				payLoadObject.put(ITEM_TYPE, (!classUids.isEmpty())? CLASS_COURSE_ASSESSMENT:SHELF_COURSE_ASSESSMENT);
+				payLoadObject.put(ITEM_TYPE, (!classUids.isEmpty()) ? CLASS_COURSE_ASSESSMENT : SHELF_COURSE_ASSESSMENT);
 			} else if (collectionType.equalsIgnoreCase(CollectionType.COLLECTION.getCollectionType())) {
 				payLoadObject.put(TYPE, COLLECTION);
-				payLoadObject.put(ITEM_TYPE, (!classUids.isEmpty())? CLASS_COURSE_COLLECTION:SHELF_COURSE_COLLECTION);
-			} else if(collectionType.equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())){
+				payLoadObject.put(ITEM_TYPE, (!classUids.isEmpty()) ? CLASS_COURSE_COLLECTION : SHELF_COURSE_COLLECTION);
+			} else if (collectionType.equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())) {
 				payLoadObject.put(TYPE, ASSESSMENT_URL);
-				payLoadObject.put(ITEM_TYPE, (!classUids.isEmpty())? CLASS_COURSE_ASSESSMENT_URL:SHELF_COURSE_ASSESSMENT_URL);
+				payLoadObject.put(ITEM_TYPE, (!classUids.isEmpty()) ? CLASS_COURSE_ASSESSMENT_URL : SHELF_COURSE_ASSESSMENT_URL);
 			}
-			
+
 			SessionContextSupport.putLogParameter(PAY_LOAD_OBJECT, payLoadObject.toString());
 			JSONObject session = SessionContextSupport.getLog().get(SESSION) != null ? new JSONObject(SessionContextSupport.getLog().get(SESSION).toString()) : new JSONObject();
 			session.put(ORGANIZATION_UID, user != null && user.getOrganization() != null ? user.getOrganization().getPartyUid() : null);
@@ -71,11 +72,14 @@ public class CollectionEventLog extends EventLog {
 		}
 	}
 
-	public void collectionItemEventLog(String collectionId, CollectionItem resource, String user, String contentType, Object data, String action) {
+	public void collectionItemEventLog(String collectionId, CollectionItem resource, String sourceGooruId, String user, String contentType, Object data, String action) {
 		try {
 			JSONObject context = SessionContextSupport.getLog().get(CONTEXT) != null ? new JSONObject(SessionContextSupport.getLog().get(CONTEXT).toString()) : new JSONObject();
+			if (StringUtils.isBlank(sourceGooruId)) {
+				sourceGooruId = resource.getContent().getGooruOid();
+			}
 			context.put(CONTENT_GOORU_ID, resource.getContent().getGooruOid());
-			context.put(SOURCE_GOORU_ID, resource.getContent().getGooruOid());
+			context.put(SOURCE_GOORU_ID, sourceGooruId);
 			context.put(PARENT_GOORU_ID, collectionId);
 			SessionContextSupport.putLogParameter(CONTEXT, context.toString());
 			JSONObject payLoadObject = SessionContextSupport.getLog().get(PAY_LOAD_OBJECT) != null ? new JSONObject(SessionContextSupport.getLog().get(PAY_LOAD_OBJECT).toString()) : new JSONObject();
@@ -86,7 +90,7 @@ public class CollectionEventLog extends EventLog {
 				payLoadObject.put(TYPE, RESOURCE);
 				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_RESOURCE);
 			}
-			if (action.equalsIgnoreCase(CREATE)){
+			if (action.equalsIgnoreCase(CREATE)) {
 				payLoadObject.put(MODE, CREATE);
 				payLoadObject.put(DATA, data);
 				SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_CREATE);
@@ -94,18 +98,16 @@ public class CollectionEventLog extends EventLog {
 				payLoadObject.put(MODE, ADD);
 				payLoadObject.put(DATA, data);
 				SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_CREATE);
-			} 
-			else if (action.equalsIgnoreCase(EDIT)) {
+			} else if (action.equalsIgnoreCase(EDIT)) {
 				payLoadObject.put(MODE, EDIT);
 				SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_EDIT);
-			} 
-			else {
+			} else {
 				SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_DELETE);
 				payLoadObject.put(MODE, DELETE);
 			}
-			payLoadObject.put(PARENT_SHARING,resource.getCollection().getSharing());
-			payLoadObject.put(ITEM_SEQUENCE,resource.getItemSequence());
-			payLoadObject.put(ITEM_ID,resource.getCollectionItemId());
+			payLoadObject.put(PARENT_SHARING, resource.getCollection().getSharing());
+			payLoadObject.put(ITEM_SEQUENCE, resource.getItemSequence());
+			payLoadObject.put(ITEM_ID, resource.getCollectionItemId());
 			SessionContextSupport.putLogParameter(PAY_LOAD_OBJECT, payLoadObject.toString());
 			JSONObject session = SessionContextSupport.getLog().get(SESSION) != null ? new JSONObject(SessionContextSupport.getLog().get(SESSION).toString()) : new JSONObject();
 			session.put(ORGANIZATION_UID, user);
@@ -114,104 +116,107 @@ public class CollectionEventLog extends EventLog {
 			LOGGER.error(_ERROR, e);
 		}
 	}
-	
 
-
-
-	 public void getMoveEventLog(String courseId, String unitId, String lessonId, Collection collection, User user, String collectionType) {
-	            try {
-	            JSONObject context = SessionContextSupport.getLog().get(CONTEXT) != null ? new JSONObject(SessionContextSupport.getLog().get(CONTEXT).toString()) : new JSONObject();
-	           context.put(CONTENT_GOORU_ID, collection.getGooruOid());
-	           context.put(PARENT_GOORU_ID, lessonId);
-	           SessionContextSupport.putLogParameter(CONTEXT, context.toString());
-	           JSONObject payLoadObject = SessionContextSupport.getLog().get(PAY_LOAD_OBJECT) != null ? new JSONObject(SessionContextSupport.getLog().get(PAY_LOAD_OBJECT).toString()) : new JSONObject();
-	           payLoadObject.put(MODE, MOVE);
-	           JSONObject session = SessionContextSupport.getLog().get(SESSION) != null ? new JSONObject(SessionContextSupport.getLog().get(SESSION).toString()) : new JSONObject();
-	           session.put(ORGANIZATION_UID, user != null && user.getOrganization() != null ? user.getOrganization().getPartyUid() : null);
-	           SessionContextSupport.putLogParameter(SESSION, session.toString());
-	           CollectionItem lesson = this.getCollectionDao().getParentCollection(collection.getContentId());
-	           payLoadObject.put(LESSON_GOORU_ID, lesson.getCollection().getGooruOid());
-	           CollectionItem unit = this.getCollectionDao().getParentCollection(lesson.getCollection().getContentId());
-	           payLoadObject.put(UNIT_GOORU_ID, unit.getCollection().getGooruOid());
-	           CollectionItem course = this.getCollectionDao().getParentCollection(unit.getCollection().getContentId());
-	           payLoadObject.put(COURSE_GOORU_ID, course.getCollection().getGooruOid());
-	           List<String> classUids = this.getClassRepository().getClassUid(courseId);
-	                   JSONArray classIds = new JSONArray();
-	                   classIds.addAll(classUids);
-	                   if (!classUids.isEmpty()) {
-	                           payLoadObject.put(CLASS_GOORU_IDS, classIds);
-	                                SessionContextSupport.putLogParameter(EVENT_NAME, CLASS_ITEM_MOVE);
-	                        } else {
-	                                payLoadObject.remove(CLASS_GOORU_IDS);
-	                                SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_CREATE);
-	                        }
-	                   if (!classUids.isEmpty() && collectionType.equalsIgnoreCase(CollectionType.ASSESSMENT.getCollectionType())) {
-	                                payLoadObject.put(ITEM_TYPE, CLASS_COURSE_ASSESSMENT);
-	                                payLoadObject.put(TYPE, ASSESSMENT);
-	                        } else if (collectionType.equalsIgnoreCase(CollectionType.ASSESSMENT.getCollectionType())) {
-	                                payLoadObject.put(ITEM_TYPE, SHELF_COURSE_ASSESSMENT);
-	                                payLoadObject.put(TYPE, ASSESSMENT);
-	                        }
-	                        if (!classUids.isEmpty() && collectionType.equalsIgnoreCase(CollectionType.COLLECTION.getCollectionType())) {
-	                                payLoadObject.put(ITEM_TYPE, CLASS_COURSE_COLLECTION);
-	                                payLoadObject.put(TYPE, COLLECTION);
-	                        } else if (collectionType.equalsIgnoreCase(CollectionType.COLLECTION.getCollectionType())) {
-	                                payLoadObject.put(ITEM_TYPE, SHELF_COURSE_COLLECTION);
-	                                payLoadObject.put(TYPE, COLLECTION);
-	                        }
-	                        if (!classUids.isEmpty() && collectionType.equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())) {
-	                                payLoadObject.put(ITEM_TYPE, CLASS_COURSE_ASSESSMENT_URL);
-	                                payLoadObject.put(TYPE, ASSESSMENT_URL);
-	                        } else if (collectionType.equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())) {
-	                                payLoadObject.put(ITEM_TYPE, SHELF_COURSE_ASSESSMENT_URL);
-	                                payLoadObject.put(TYPE, ASSESSMENT_URL);
-	                        }
-	           payLoadObject.put(TARGET_GOORU_ID, lessonId );
-	           SessionContextSupport.putLogParameter(PAY_LOAD_OBJECT, payLoadObject.toString());
-	           } catch (Exception e) {
-	                   LOGGER.error(_ERROR, e);
-	           }
-	   }
-		public void collectionUpdateEventLog(String lessonId, CollectionItem collection, User user) {
-			try {
-				String collectionType = collection.getContent().getContentType().getName();
-				JSONObject context = SessionContextSupport.getLog().get(CONTEXT) != null ? new JSONObject(SessionContextSupport.getLog().get(CONTEXT).toString()) : new JSONObject();
-				context.put(CONTENT_GOORU_ID, collection.getContent().getGooruOid());
-				context.put(PARENT_GOORU_ID, lessonId);
-				SessionContextSupport.putLogParameter(CONTEXT, context.toString());
-				SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_EDIT);
-				JSONObject payLoadObject = SessionContextSupport.getLog().get(PAY_LOAD_OBJECT) != null ? new JSONObject(SessionContextSupport.getLog().get(PAY_LOAD_OBJECT).toString()) : new JSONObject();
-				payLoadObject.put(LESSON_GOORU_ID, lessonId);
-				payLoadObject.put(MODE, EDIT);
-				payLoadObject.put(ITEM_SEQUENCE,collection.getItemSequence());
-				payLoadObject.put(ITEM_ID,collection.getCollectionItemId());
-				payLoadObject.put(TYPE, collectionType);
-				if (collectionType.equalsIgnoreCase(CollectionType.ASSESSMENT.getCollectionType())) {
-					payLoadObject.put(ITEM_TYPE, SHELF_COURSE_ASSESSMENT);
-				} else if (collectionType.equalsIgnoreCase(CollectionType.COLLECTION.getCollectionType())) {
-					payLoadObject.put(ITEM_TYPE, SHELF_COURSE_COLLECTION);
-				} else if(collectionType.equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())){
-					payLoadObject.put(ITEM_TYPE, SHELF_COURSE_ASSESSMENT_URL);
-				} else if (collectionType.equalsIgnoreCase(QUESTION)) {
-					payLoadObject.put(ITEM_TYPE, SHELF_COURSE_QUESTION);
-				} else if (collectionType.equalsIgnoreCase(RESOURCE)) {
-					payLoadObject.put(ITEM_TYPE, SHELF_COURSE_RESOURCE);
-				}
-				
-				SessionContextSupport.putLogParameter(PAY_LOAD_OBJECT, payLoadObject.toString());
-				JSONObject session = SessionContextSupport.getLog().get(SESSION) != null ? new JSONObject(SessionContextSupport.getLog().get(SESSION).toString()) : new JSONObject();
-				session.put(ORGANIZATION_UID, user != null && user.getOrganization() != null ? user.getOrganization().getPartyUid() : null);
-				SessionContextSupport.putLogParameter(SESSION, session.toString());
-			} catch (Exception e) {
-				LOGGER.error(_ERROR, e);
+	public void getMoveEventLog(String courseId, String unitId, String lessonId, Collection collection, User user, String collectionType) {
+		try {
+			JSONObject context = SessionContextSupport.getLog().get(CONTEXT) != null ? new JSONObject(SessionContextSupport.getLog().get(CONTEXT).toString()) : new JSONObject();
+			context.put(CONTENT_GOORU_ID, collection.getGooruOid());
+			context.put(PARENT_GOORU_ID, lessonId);
+			SessionContextSupport.putLogParameter(CONTEXT, context.toString());
+			JSONObject payLoadObject = SessionContextSupport.getLog().get(PAY_LOAD_OBJECT) != null ? new JSONObject(SessionContextSupport.getLog().get(PAY_LOAD_OBJECT).toString()) : new JSONObject();
+			payLoadObject.put(MODE, MOVE);
+			JSONObject session = SessionContextSupport.getLog().get(SESSION) != null ? new JSONObject(SessionContextSupport.getLog().get(SESSION).toString()) : new JSONObject();
+			session.put(ORGANIZATION_UID, user != null && user.getOrganization() != null ? user.getOrganization().getPartyUid() : null);
+			SessionContextSupport.putLogParameter(SESSION, session.toString());
+			CollectionItem lesson = this.getCollectionDao().getParentCollection(collection.getContentId());
+			payLoadObject.put(LESSON_GOORU_ID, lesson.getCollection().getGooruOid());
+			CollectionItem unit = this.getCollectionDao().getParentCollection(lesson.getCollection().getContentId());
+			payLoadObject.put(UNIT_GOORU_ID, unit.getCollection().getGooruOid());
+			CollectionItem course = this.getCollectionDao().getParentCollection(unit.getCollection().getContentId());
+			payLoadObject.put(COURSE_GOORU_ID, course.getCollection().getGooruOid());
+			List<String> classUids = this.getClassRepository().getClassUid(courseId);
+			JSONArray classIds = new JSONArray();
+			classIds.addAll(classUids);
+			if (!classUids.isEmpty()) {
+				payLoadObject.put(CLASS_GOORU_IDS, classIds);
+				SessionContextSupport.putLogParameter(EVENT_NAME, CLASS_ITEM_MOVE);
+			} else {
+				payLoadObject.remove(CLASS_GOORU_IDS);
+				SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_CREATE);
 			}
+			if (!classUids.isEmpty() && collectionType.equalsIgnoreCase(CollectionType.ASSESSMENT.getCollectionType())) {
+				payLoadObject.put(ITEM_TYPE, CLASS_COURSE_ASSESSMENT);
+				payLoadObject.put(TYPE, ASSESSMENT);
+			} else if (collectionType.equalsIgnoreCase(CollectionType.ASSESSMENT.getCollectionType())) {
+				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_ASSESSMENT);
+				payLoadObject.put(TYPE, ASSESSMENT);
+			}
+			if (!classUids.isEmpty() && collectionType.equalsIgnoreCase(CollectionType.COLLECTION.getCollectionType())) {
+				payLoadObject.put(ITEM_TYPE, CLASS_COURSE_COLLECTION);
+				payLoadObject.put(TYPE, COLLECTION);
+			} else if (collectionType.equalsIgnoreCase(CollectionType.COLLECTION.getCollectionType())) {
+				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_COLLECTION);
+				payLoadObject.put(TYPE, COLLECTION);
+			}
+			if (!classUids.isEmpty() && collectionType.equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())) {
+				payLoadObject.put(ITEM_TYPE, CLASS_COURSE_ASSESSMENT_URL);
+				payLoadObject.put(TYPE, ASSESSMENT_URL);
+			} else if (collectionType.equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())) {
+				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_ASSESSMENT_URL);
+				payLoadObject.put(TYPE, ASSESSMENT_URL);
+			}
+			payLoadObject.put(TARGET_GOORU_ID, lessonId);
+			SessionContextSupport.putLogParameter(PAY_LOAD_OBJECT, payLoadObject.toString());
+		} catch (Exception e) {
+			LOGGER.error(_ERROR, e);
 		}
+	}
+
+	public void collectionUpdateEventLog(String lessonId, CollectionItem collection, User user) {
+		try {
+			String collectionType = collection.getContent().getContentType().getName();
+			JSONObject context = SessionContextSupport.getLog().get(CONTEXT) != null ? new JSONObject(SessionContextSupport.getLog().get(CONTEXT).toString()) : new JSONObject();
+			context.put(CONTENT_GOORU_ID, collection.getContent().getGooruOid());
+			context.put(PARENT_GOORU_ID, lessonId);
+			SessionContextSupport.putLogParameter(CONTEXT, context.toString());
+			SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_EDIT);
+			JSONObject payLoadObject = SessionContextSupport.getLog().get(PAY_LOAD_OBJECT) != null ? new JSONObject(SessionContextSupport.getLog().get(PAY_LOAD_OBJECT).toString()) : new JSONObject();
+			payLoadObject.put(LESSON_GOORU_ID, lessonId);
+			payLoadObject.put(MODE, EDIT);
+			payLoadObject.put(ITEM_SEQUENCE, collection.getItemSequence());
+			payLoadObject.put(ITEM_ID, collection.getCollectionItemId());
+			payLoadObject.put(TYPE, collectionType);
+			if (collectionType.equalsIgnoreCase(CollectionType.ASSESSMENT.getCollectionType())) {
+				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_ASSESSMENT);
+			} else if (collectionType.equalsIgnoreCase(CollectionType.COLLECTION.getCollectionType())) {
+				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_COLLECTION);
+			} else if (collectionType.equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())) {
+				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_ASSESSMENT_URL);
+			} else if (collectionType.equalsIgnoreCase(QUESTION)) {
+				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_QUESTION);
+			} else if (collectionType.equalsIgnoreCase(RESOURCE)) {
+				payLoadObject.put(ITEM_TYPE, SHELF_COURSE_RESOURCE);
+			}
+
+			SessionContextSupport.putLogParameter(PAY_LOAD_OBJECT, payLoadObject.toString());
+			JSONObject session = SessionContextSupport.getLog().get(SESSION) != null ? new JSONObject(SessionContextSupport.getLog().get(SESSION).toString()) : new JSONObject();
+			session.put(ORGANIZATION_UID, user != null && user.getOrganization() != null ? user.getOrganization().getPartyUid() : null);
+			SessionContextSupport.putLogParameter(SESSION, session.toString());
+		} catch (Exception e) {
+			LOGGER.error(_ERROR, e);
+		}
+	}
+
 	public CollectionDao getCollectionDao() {
 		return collectionDao;
 	}
 
 	public ClassRepository getClassRepository() {
 		return classRepository;
+	}
+
+	public void collectionItemEventLog(String collectionId, CollectionItem collectionItem, String user, String contentType, Object data, String action) {
+		this.collectionItemEventLog(collectionId, collectionItem, null, user, contentType, data, action);
 	}
 
 }

--- a/api/src/main/java/org/ednovo/gooru/domain/service/eventlogs/CollectionEventLog.java
+++ b/api/src/main/java/org/ednovo/gooru/domain/service/eventlogs/CollectionEventLog.java
@@ -72,13 +72,13 @@ public class CollectionEventLog extends EventLog {
 		}
 	}
 
-	public void collectionItemEventLog(String collectionId, CollectionItem resource, String sourceGooruId, String user, String contentType, Object data, String action) {
+	public void collectionItemEventLog(String collectionId, CollectionItem collectionItem, String sourceGooruId, String user, String contentType, Object data, String action) {
 		try {
 			JSONObject context = SessionContextSupport.getLog().get(CONTEXT) != null ? new JSONObject(SessionContextSupport.getLog().get(CONTEXT).toString()) : new JSONObject();
 			if (StringUtils.isBlank(sourceGooruId)) {
-				sourceGooruId = resource.getContent().getGooruOid();
+				sourceGooruId = collectionItem.getContent().getGooruOid();
 			}
-			context.put(CONTENT_GOORU_ID, resource.getContent().getGooruOid());
+			context.put(CONTENT_GOORU_ID, collectionItem.getContent().getGooruOid());
 			context.put(SOURCE_GOORU_ID, sourceGooruId);
 			context.put(PARENT_GOORU_ID, collectionId);
 			SessionContextSupport.putLogParameter(CONTEXT, context.toString());
@@ -105,9 +105,9 @@ public class CollectionEventLog extends EventLog {
 				SessionContextSupport.putLogParameter(EVENT_NAME, ITEM_DELETE);
 				payLoadObject.put(MODE, DELETE);
 			}
-			payLoadObject.put(PARENT_SHARING, resource.getCollection().getSharing());
-			payLoadObject.put(ITEM_SEQUENCE, resource.getItemSequence());
-			payLoadObject.put(ITEM_ID, resource.getCollectionItemId());
+			payLoadObject.put(PARENT_SHARING, collectionItem.getCollection().getSharing());
+			payLoadObject.put(ITEM_SEQUENCE, collectionItem.getItemSequence());
+			payLoadObject.put(ITEM_ID, collectionItem.getCollectionItemId());
 			SessionContextSupport.putLogParameter(PAY_LOAD_OBJECT, payLoadObject.toString());
 			JSONObject session = SessionContextSupport.getLog().get(SESSION) != null ? new JSONObject(SessionContextSupport.getLog().get(SESSION).toString()) : new JSONObject();
 			session.put(ORGANIZATION_UID, user);


### PR DESCRIPTION
While adding a question resource to collection, we need a sourceGooruId field in the event for statistical aggregation. 

So overloaded collectionItemEventLog method by adding sourceGooruId parameter. This is because we are creating a new question resource while adding, so we couldn't get source gooru Id in our current approach.