### PR TITLE
Added sharing and collection item ids in item.edit event

### DIFF
--- a/api/src/main/java/org/ednovo/gooru/domain/service/collection/CollectionBoServiceImpl.java
+++ b/api/src/main/java/org/ednovo/gooru/domain/service/collection/CollectionBoServiceImpl.java
@@ -152,6 +152,7 @@ public class CollectionBoServiceImpl extends AbstractResourceServiceImpl impleme
 		boolean hasUnrestrictedContentAccess = this.getOperationAuthorizer().hasUnrestrictedContentAccess(collectionId, user);
 		// TO-Do add validation for collection type and collaborator validation
 		Collection collection = getCollectionDao().getCollection(collectionId);
+		String collectionOldSharing = collection.getSharing(); 
 		if (newCollection.getSharing() != null && (newCollection.getSharing().equalsIgnoreCase(Sharing.PRIVATE.getSharing()) || newCollection.getSharing().equalsIgnoreCase(Sharing.PUBLIC.getSharing()) || newCollection.getSharing().equalsIgnoreCase(Sharing.ANYONEWITHLINK.getSharing()))) {
 			if (!newCollection.getSharing().equalsIgnoreCase(PUBLIC)) {
 				collection.setPublishStatusId(null);
@@ -201,13 +202,12 @@ public class CollectionBoServiceImpl extends AbstractResourceServiceImpl impleme
 		}
 		updateCollection(collection, newCollection, user);
 
-
 		if (!collection.getCollectionType().equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())) {
 			getIndexHandler().setReIndexRequest(collection.getGooruOid(), IndexProcessor.INDEX, SCOLLECTION, null, false, false);
 		}
 		
 	    CollectionItem collectionItem = getCollectionDao().getCollectionItem(parentId, collectionId, user.getPartyUid());
-		getCollectionEventLog().collectionUpdateEventLog(parentId, collectionItem, user);
+		getCollectionEventLog().collectionUpdateEventLog(parentId, collectionItem, collectionOldSharing, user);
 		Map<String, Object> data = generateCollectionMetaData(collection, newCollection, user);
 		if (data != null && data.size() > 0) {
 			ContentMeta contentMeta = this.getContentRepository().getContentMeta(collection.getContentId());

--- a/api/src/main/java/org/ednovo/gooru/domain/service/collection/CollectionBoServiceImpl.java
+++ b/api/src/main/java/org/ednovo/gooru/domain/service/collection/CollectionBoServiceImpl.java
@@ -205,9 +205,10 @@ public class CollectionBoServiceImpl extends AbstractResourceServiceImpl impleme
 		if (!collection.getCollectionType().equalsIgnoreCase(ResourceType.Type.ASSESSMENT_URL.getType())) {
 			getIndexHandler().setReIndexRequest(collection.getGooruOid(), IndexProcessor.INDEX, SCOLLECTION, null, false, false);
 		}
-		
-	    CollectionItem collectionItem = getCollectionDao().getCollectionItem(parentId, collectionId, user.getPartyUid());
-		getCollectionEventLog().collectionUpdateEventLog(parentId, collectionItem, collectionOldSharing, user);
+		if(parentId != null) {
+			CollectionItem collectionItem = getCollectionDao().getCollectionItem(parentId, collectionId, user.getPartyUid());
+			getCollectionEventLog().collectionUpdateEventLog(parentId, collectionItem, collectionOldSharing, user);
+		}
 		Map<String, Object> data = generateCollectionMetaData(collection, newCollection, user);
 		if (data != null && data.size() > 0) {
 			ContentMeta contentMeta = this.getContentRepository().getContentMeta(collection.getContentId());

--- a/api/src/main/java/org/ednovo/gooru/domain/service/eventlogs/CollectionEventLog.java
+++ b/api/src/main/java/org/ednovo/gooru/domain/service/eventlogs/CollectionEventLog.java
@@ -212,7 +212,7 @@ public class CollectionEventLog extends EventLog {
 			if(collectionType.matches(COLLECTION_TYPES_FOR_EVENT) && !StringUtils.trimToEmpty(collectionOldSharing).equalsIgnoreCase(collectionItem.getContent().getSharing())) {
 				payLoadObject.put(PREVIOUS_SHARING, StringUtils.trimToEmpty(collectionOldSharing));
 				payLoadObject.put(CONTENT_SHARING, collectionItem.getContent().getSharing());
-				List<String> collectionItemIds = getCollectionDao().getCollectionItemIds(collectionItem.getContent().getGooruOid());
+				List<String> collectionItemIds = getCollectionDao().getCollectionItemIds(collectionItem.getContent().getContentId());
 				if (collectionItemIds != null) {
 					payLoadObject.put(COLLECTION_ITEM_IDS, collectionItemIds.toString());
 				}

--- a/api/src/main/java/org/ednovo/gooru/infrastructure/persistence/hibernate/CollectionDao.java
+++ b/api/src/main/java/org/ednovo/gooru/infrastructure/persistence/hibernate/CollectionDao.java
@@ -45,6 +45,6 @@ public interface CollectionDao extends BaseRepository {
 	
 	void updateClassByCourse(Long contentId);
 
-	List<String> getCollectionItemIds(String collectionId);
+	List<String> getCollectionItemIds(Long collectionId);
 
 }

--- a/api/src/main/java/org/ednovo/gooru/infrastructure/persistence/hibernate/CollectionDao.java
+++ b/api/src/main/java/org/ednovo/gooru/infrastructure/persistence/hibernate/CollectionDao.java
@@ -45,4 +45,6 @@ public interface CollectionDao extends BaseRepository {
 	
 	void updateClassByCourse(Long contentId);
 
+	List<String> getCollectionItemIds(String collectionId);
+
 }

--- a/api/src/main/java/org/ednovo/gooru/infrastructure/persistence/hibernate/CollectionDaoHibernate.java
+++ b/api/src/main/java/org/ednovo/gooru/infrastructure/persistence/hibernate/CollectionDaoHibernate.java
@@ -56,7 +56,7 @@ public class CollectionDaoHibernate extends BaseRepositoryHibernate implements C
 
 	private static final String UPDATE_CONTENT_ID = "update class set course_content_id=null where course_content_id=:contentId";
 	
-	private static final String GET_COLLECTION_ITEM_IDS = "SELECT rc.gooru_oid FROM content c INNER JOIN collection_item ci ON (ci.collection_content_id = c.content_id) INNER JOIN content rc ON (rc.content_id = ci.resource_content_id) WHERE c.gooru_oid = :collectionId";
+	private static final String GET_COLLECTION_ITEM_IDS = "SELECT rc.gooru_oid FROM collection_item ci INNER JOIN content rc ON (rc.content_id = ci.resource_content_id) WHERE ci.collection_content_id = :collectionId";
 
 	@Override
 	public Collection getCollection(String collectionId) {
@@ -266,7 +266,7 @@ public class CollectionDaoHibernate extends BaseRepositoryHibernate implements C
 	}
 
 	@Override
-	public List<String> getCollectionItemIds(String collectionId) {
+	public List<String> getCollectionItemIds(Long collectionId) {
 		Query query = getSession().createSQLQuery(GET_COLLECTION_ITEM_IDS);
 		query.setParameter(COLLECTION_ID, collectionId);
 		return list(query);

--- a/api/src/main/java/org/ednovo/gooru/infrastructure/persistence/hibernate/CollectionDaoHibernate.java
+++ b/api/src/main/java/org/ednovo/gooru/infrastructure/persistence/hibernate/CollectionDaoHibernate.java
@@ -55,6 +55,8 @@ public class CollectionDaoHibernate extends BaseRepositoryHibernate implements C
 	private static final String COLLECTION_LIST = "FROM Collection where gooruOid in (:collectionId)";
 
 	private static final String UPDATE_CONTENT_ID = "update class set course_content_id=null where course_content_id=:contentId";
+	
+	private static final String GET_COLLECTION_ITEM_IDS = "SELECT rc.gooru_oid FROM content c INNER JOIN collection_item ci ON (ci.collection_content_id = c.content_id) INNER JOIN content rc ON (rc.content_id = ci.resource_content_id) WHERE c.gooru_oid = :collectionId";
 
 	@Override
 	public Collection getCollection(String collectionId) {
@@ -263,4 +265,10 @@ public class CollectionDaoHibernate extends BaseRepositoryHibernate implements C
 		return list(query);
 	}
 
+	@Override
+	public List<String> getCollectionItemIds(String collectionId) {
+		Query query = getSession().createSQLQuery(GET_COLLECTION_ITEM_IDS);
+		query.setParameter(COLLECTION_ID, collectionId);
+		return list(query);
+	}
 }

--- a/gooru-core/src/main/java/org/ednovo/gooru/core/constant/ParameterProperties.java
+++ b/gooru-core/src/main/java/org/ednovo/gooru/core/constant/ParameterProperties.java
@@ -2934,11 +2934,4 @@ public interface ParameterProperties {
     
     String CLASS_USER_ADD = "classpage.user.add";
 
-    String PREVIOUS_SHARING = "previousSharing";
-    
-    String CONTENT_SHARING = "contentSharing";
-    
-    String COLLECTION_TYPES_FOR_EVENT = "collection|assessment";
-    
-    String COLLECTION_ITEM_IDS = "collectionItemIds";
 }

--- a/gooru-core/src/main/java/org/ednovo/gooru/core/constant/ParameterProperties.java
+++ b/gooru-core/src/main/java/org/ednovo/gooru/core/constant/ParameterProperties.java
@@ -2931,5 +2931,12 @@ public interface ParameterProperties {
     String CLASS_USER_REMOVE = "classpage.user.remove";
     
     String CLASS_USER_ADD = "classpage.user.add";
+
+    String PREVIOUS_SHARING = "previousSharing";
     
+    String CONTENT_SHARING = "contentSharing";
+    
+    String COLLECTION_TYPES_FOR_EVENT = "collection|assessment";
+    
+    String COLLECTION_ITEM_IDS = "collectionItemIds";
 }


### PR DESCRIPTION
Added previous sharing, content sharing and collectionItemIds field in the "item.edit" event. 

Using the above fields we can update the resource added count, if collection's sharing changed.